### PR TITLE
feat: Add support for NBIRTH and NDEATH messages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,11 @@ jobs:
   test:
     name: Build and test
     runs-on: ubuntu-latest
+    services:
+      hivemq:
+        image: hivemq/hivemq-ce:2023.9
+        ports:
+          - 1883:1883
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -17,6 +22,8 @@ jobs:
         run: go build -v ./...
 
       - name: Test
+        env:
+          MQTT_BROKER_URL: "tcp://localhost:1883"
         run: go test -v ./...
 
   lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,14 @@ Make sure that all unit tests pass by running:
 go test ./...
 ```
 
-Integration tests are available and can be run by setting the INTEGRATION environment variable:
+Integration tests are available and can be run by setting the MQTT_BROKER_URL environment variable:
 
 ```bash
-INTEGRATION=true go test ./...
+MQTT_BROKER_URL=tcp://localhost:1883 go test ./...
 ```
+
+The provided [docker-compose](docker-compose.yml) file contains a [HiveMQ](https://github.com/hivemq/hivemq-community-edition)
+service that can be used to run the integration tests against a local broker.
 
 ## Commit Messages
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.9'
+services:
+  hivemq:
+    image: hivemq/hivemq-ce:2023.9
+    ports:
+      - "1883:1883"

--- a/edge_node.go
+++ b/edge_node.go
@@ -1,0 +1,134 @@
+package sparkplughost
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/EvergenEnergy/sparkplughost/protobuf"
+)
+
+// EdgeNodeDescriptor is the combination of the
+// Group ID and Edge Node ID.
+// No two Edge Nodes within a Sparkplug environment can have the same
+// Group ID and same Edge Node ID.
+type EdgeNodeDescriptor struct {
+	GroupID    string
+	EdgeNodeID string
+}
+
+type edgeNode struct {
+	descriptor          EdgeNodeDescriptor
+	online              bool
+	lastOnlineAt        time.Time
+	lastOfflineAt       time.Time
+	birthSequenceNumber int64
+	lastSequenceNumber  int64
+}
+
+type edgeNodeManager struct {
+	mu            sync.Mutex
+	nodes         map[EdgeNodeDescriptor]edgeNode
+	metrics       map[EdgeNodeDescriptor]*edgeNodeMetrics
+	metricHandler MetricHandler
+}
+
+func newEdgeNodeManager(metricHandler MetricHandler) *edgeNodeManager {
+	return &edgeNodeManager{
+		nodes:         make(map[EdgeNodeDescriptor]edgeNode),
+		metrics:       make(map[EdgeNodeDescriptor]*edgeNodeMetrics),
+		metricHandler: metricHandler,
+	}
+}
+
+func (m *edgeNodeManager) edgeNodeOnline(edgeNodeDescriptor EdgeNodeDescriptor, payload *protobuf.Payload) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	bdSeq, err := birthSequenceNumber(payload)
+	if err != nil {
+		return err
+	}
+
+	if payload.Seq == nil || payload.GetSeq() != 0 {
+		return fmt.Errorf("the NBIRTH message MUST include a sequence number in the payload and it MUST have a value of 0")
+	}
+
+	metrics := newEdgeNodeMetrics(edgeNodeDescriptor)
+
+	err = metrics.addNodeBirthMetrics(payload.GetMetrics())
+	if err != nil {
+		return err
+	}
+
+	newNode := edgeNode{
+		descriptor:          edgeNodeDescriptor,
+		online:              true,
+		lastOnlineAt:        time.UnixMilli(int64(payload.GetTimestamp())),
+		birthSequenceNumber: bdSeq,
+		lastSequenceNumber:  0,
+	}
+
+	m.nodes[newNode.descriptor] = newNode
+	m.metrics[newNode.descriptor] = metrics
+
+	for _, metric := range metrics.nodeMetrics {
+		m.metricHandler(metric)
+	}
+
+	return nil
+}
+
+func (m *edgeNodeManager) edgeNodeOffline(edgeNodeDescriptor EdgeNodeDescriptor, payload *protobuf.Payload) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	bdSeq, err := birthSequenceNumber(payload)
+	if err != nil {
+		return err
+	}
+
+	node, found := m.nodes[edgeNodeDescriptor]
+	if !found {
+		// we received a death certificate for a node we knew nothing about
+		// ignore...
+		return nil
+	}
+
+	if bdSeq != node.birthSequenceNumber {
+		// timing with Will Messages may result in NDEATH messages arriving after a new/next NBIRTH message
+		// has been received.
+		// if the birth sequences don't match it should be safe to ignore this message
+		return nil
+	}
+
+	// after receiving a Node death message we should set the node and all its devices status as offline
+	// using the current host application UTC timestamp.
+	// All metrics (both for the node and its devices) should also be set to STALE.
+	currentTime := time.Now().UTC()
+	node.online = false
+	node.lastOfflineAt = currentTime
+
+	metrics, found := m.metrics[edgeNodeDescriptor]
+	if found {
+		metrics.setNodeMetricsAsStale()
+		for _, metric := range metrics.nodeMetrics {
+			m.metricHandler(metric)
+		}
+	}
+
+	m.nodes[edgeNodeDescriptor] = node
+
+	return nil
+}
+
+func birthSequenceNumber(payload *protobuf.Payload) (int64, error) {
+	for _, metric := range payload.Metrics {
+		if metric.GetName() == "bdSeq" {
+			return int64(metric.GetLongValue()), nil
+		}
+	}
+
+	return 0, errors.New("bdSeq metric not found")
+}

--- a/host.go
+++ b/host.go
@@ -1,0 +1,205 @@
+package sparkplughost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/EvergenEnergy/sparkplughost/protobuf"
+	"github.com/eclipse/paho.mqtt.golang"
+	"google.golang.org/protobuf/proto"
+)
+
+type HostApplication struct {
+	mqttClient               mqtt.Client
+	hostID                   string
+	brokerURL                string
+	lastWillMessageTimestamp time.Time
+	logger                   *slog.Logger
+	edgeNodeManager          *edgeNodeManager
+	disconnectTimeout        time.Duration
+}
+
+func NewHostApplication(brokerURL, hostID string, opts ...Option) *HostApplication {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return &HostApplication{
+		hostID:            hostID,
+		brokerURL:         brokerURL,
+		logger:            cfg.logger,
+		edgeNodeManager:   newEdgeNodeManager(cfg.metricHandler),
+		disconnectTimeout: cfg.disconnectTimeout,
+	}
+}
+
+// Run will connect to the mqtt broker and block until
+// ctx is canceled.
+func (h *HostApplication) Run(ctx context.Context) error {
+	if h.mqttClient != nil && h.mqttClient.IsConnected() {
+		h.mqttClient.Disconnect(uint(h.disconnectTimeout.Milliseconds()))
+	}
+
+	h.initClient()
+
+	if token := h.mqttClient.Connect(); token.Wait() && token.Error() != nil {
+		return token.Error()
+	}
+
+	// wait until the context is cancelled
+	<-ctx.Done()
+
+	// disconnect gracefully by publishing the death certificate before
+	// sending the disconnect command to the MQTT broker.
+	token := h.publishOnlineStatus(false, time.Now().UTC())
+	if token.Wait() && token.Error() != nil {
+		return token.Error()
+	}
+
+	h.mqttClient.Disconnect(uint(h.disconnectTimeout.Milliseconds()))
+	return nil
+}
+
+func (h *HostApplication) initClient() {
+	mqttOpts := mqtt.NewClientOptions()
+	mqttOpts.AddBroker(h.brokerURL)
+	mqttOpts.SetClientID(h.hostID)
+	mqttOpts.SetCleanSession(true)
+	mqttOpts.SetAutoReconnect(true)
+	mqttOpts.SetOrderMatters(true)
+	mqttOpts.SetOnConnectHandler(h.onConnect)
+	mqttOpts.SetReconnectingHandler(h.onReconnect)
+	mqttOpts.SetDefaultPublishHandler(func(_ mqtt.Client, message mqtt.Message) {
+		h.logger.Info("received unexpected message", "topic", message.Topic())
+	})
+
+	h.setLastWill(mqttOpts)
+
+	h.mqttClient = mqtt.NewClient(mqttOpts)
+}
+
+func (h *HostApplication) stateTopic() string {
+	return fmt.Sprintf("%s/%s/%s", sparkplugbNamespace, messageTypeSTATE, h.hostID)
+}
+
+func (h *HostApplication) onConnect(client mqtt.Client) {
+	hostStateTopic := h.stateTopic()
+
+	if token := client.Subscribe(hostStateTopic, byte(1), h.stateHandler); token.Wait() && token.Error() != nil {
+		h.logger.Error(
+			"error subscribing to STATE topic",
+			"topic",
+			hostStateTopic,
+			"error",
+			token.Error().Error(),
+		)
+	}
+
+	// The Sparkplug Host Application MUST publish a
+	// Sparkplug Host Application BIRTH message to the MQTT Server immediately after
+	// successfully subscribing its own spBv1.0/STATE/sparkplug_host_id topic.
+	h.publishOnlineStatus(true, h.lastWillMessageTimestamp)
+
+	client.Subscribe(fmt.Sprintf("%s/+/NBIRTH/+", sparkplugbNamespace), byte(0), h.nodeBirthHandler)
+	client.Subscribe(fmt.Sprintf("%s/+/NDEATH/+", sparkplugbNamespace), byte(0), h.nodeDeathHandler)
+}
+
+func (h *HostApplication) onReconnect(_ mqtt.Client, options *mqtt.ClientOptions) {
+	h.setLastWill(options)
+}
+
+func (h *HostApplication) stateHandler(client mqtt.Client, message mqtt.Message) {
+	// the STATE topic uses QOS 1, so we need to make sure we ACK the message
+	defer message.Ack()
+
+	var status statusPayload
+	if err := json.Unmarshal(message.Payload(), &status); err != nil {
+		h.logger.Error("failed to unmarshal STATE payload", "error", err.Error())
+		return
+	}
+
+	// if at any point the Host Application is delivered a STATE message on
+	// its own Host Application ID with an online value of false, it MUST immediately republish its STATE
+	// message to the same MQTT Server with an online value of true and the timestamp set to the same
+	// value that was used for the timestamp in its own prior MQTT CONNECT packet Will Message
+	// payload
+	if !status.Online {
+		// this runs on a separate goroutine due to paho's mqtt recommendation
+		// that "callback functions must not block or call functions within this
+		// package that may block (e.g. Publish)"
+		go h.publishOnlineStatus(true, h.lastWillMessageTimestamp)
+	}
+}
+
+func (h *HostApplication) setLastWill(mqttOpts *mqtt.ClientOptions) {
+	h.lastWillMessageTimestamp = time.Now().UTC()
+
+	payload, _ := json.Marshal(statusPayload{
+		Online:    false,
+		Timestamp: h.lastWillMessageTimestamp.UnixMilli(),
+	})
+
+	mqttOpts.SetWill(h.stateTopic(), string(payload), byte(1), true)
+}
+
+func (h *HostApplication) publishOnlineStatus(online bool, timestamp time.Time) mqtt.Token {
+	payload, _ := json.Marshal(statusPayload{
+		Online:    online,
+		Timestamp: timestamp.UnixMilli(),
+	})
+
+	return h.mqttClient.Publish(h.stateTopic(), byte(1), true, payload)
+}
+
+func (h *HostApplication) nodeBirthHandler(_ mqtt.Client, message mqtt.Message) {
+	topic, err := parseTopic(message.Topic())
+	if err != nil {
+		h.logger.Error("Invalid topic on NBIRTH message", "error", err.Error())
+		return
+	}
+
+	var payload protobuf.Payload
+
+	err = proto.Unmarshal(message.Payload(), &payload)
+	if err != nil {
+		h.logger.Error("Failed to unmarshal protobuf payload on NBIRTH", "error", err.Error())
+		return
+	}
+
+	err = h.edgeNodeManager.edgeNodeOnline(topic.edgeNodeDescriptor(), &payload)
+	if err != nil {
+		h.logger.Error(err.Error(), "groupID", topic.groupID, "edgeNodeID", topic.edgeNodeID)
+		return
+	}
+}
+
+func (h *HostApplication) nodeDeathHandler(_ mqtt.Client, message mqtt.Message) {
+	topic, err := parseTopic(message.Topic())
+	if err != nil {
+		h.logger.Error("Invalid topic on NDEATH message", "error", err.Error())
+		return
+	}
+
+	var payload protobuf.Payload
+
+	err = proto.Unmarshal(message.Payload(), &payload)
+	if err != nil {
+		h.logger.Error("Failed to unmarshal protobuf payload on NDEATH", "error", err.Error())
+		return
+	}
+
+	err = h.edgeNodeManager.edgeNodeOffline(topic.edgeNodeDescriptor(), &payload)
+	if err != nil {
+		h.logger.Error(err.Error(), "groupID", topic.groupID, "edgeNodeID", topic.edgeNodeID)
+		return
+	}
+}
+
+type statusPayload struct {
+	Online    bool  `json:"online"`
+	Timestamp int64 `json:"timestamp"`
+}

--- a/host_test.go
+++ b/host_test.go
@@ -1,0 +1,255 @@
+package sparkplughost_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/EvergenEnergy/sparkplughost"
+	"github.com/EvergenEnergy/sparkplughost/protobuf"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHostConnectsAndSendsBirthCertificate(t *testing.T) {
+	checkIntegrationTestEnvVar(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	hostID := fmt.Sprintf("test-host-%d", rand.Int())
+	host := sparkplughost.NewHostApplication(testBrokerURL(), hostID)
+
+	go func() {
+		err := host.Run(ctx)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	mqttClient := testMqttClient(t)
+	defer mqttClient.Disconnect(250)
+
+	waitForHostStatus(t, mqttClient, hostID, true)
+}
+
+func TestHostPublishesDeathCertificateWhenStoppingGracefully(t *testing.T) {
+	checkIntegrationTestEnvVar(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	hostID := fmt.Sprintf("test-host-%d", rand.Int())
+	host := sparkplughost.NewHostApplication(testBrokerURL(), hostID)
+
+	go func() {
+		err := host.Run(ctx)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	mqttClient := testMqttClient(t)
+	defer mqttClient.Disconnect(250)
+
+	waitForHostStatus(t, mqttClient, hostID, false)
+}
+
+func TestHandlesMetricsOnNodeBirth(t *testing.T) {
+	checkIntegrationTestEnvVar(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	receivedMetrics := make(map[string]sparkplughost.HostMetric)
+	metricHandler := func(metric sparkplughost.HostMetric) {
+		receivedMetrics[metric.Metric.GetName()] = metric
+	}
+
+	hostID := fmt.Sprintf("test-host-%d", rand.Int())
+	host := sparkplughost.NewHostApplication(testBrokerURL(), hostID, sparkplughost.WithMetricHandler(metricHandler))
+
+	mqttClient := testMqttClient(t)
+	defer mqttClient.Disconnect(250)
+
+	go func() {
+		err := host.Run(ctx)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	waitForHostStatus(t, mqttClient, hostID, true)
+
+	birthPayload := &protobuf.Payload{
+		Timestamp: proto.Uint64(uint64(time.Now().UnixMilli())),
+		Metrics: []*protobuf.Payload_Metric{
+			{
+				Name:     proto.String("bdSeq"),
+				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 0},
+			},
+			{
+				Name:     proto.String("foo"),
+				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
+			},
+		},
+		Seq: proto.Uint64(0),
+	}
+	protoPayload, _ := proto.Marshal(birthPayload)
+	mqttClient.Publish("spBv1.0/test-group/NBIRTH/test-node", byte(0), false, protoPayload)
+
+	// Give the host some time to process the message
+	<-ctx.Done()
+
+	if len(receivedMetrics) != 2 {
+		t.Errorf("received %d metrics on node birth but expected 2", len(receivedMetrics))
+	}
+
+	fooMetric := receivedMetrics["foo"]
+
+	if got := fooMetric.EdgeNodeDescriptor.GroupID; got != "test-group" {
+		t.Errorf("got metric with Group %s but expected test-group", got)
+	}
+	if got := fooMetric.EdgeNodeDescriptor.EdgeNodeID; got != "test-node" {
+		t.Errorf("got metric with Edge Node ID %s but expected test-node", got)
+	}
+}
+
+func TestHandlesMetricsOnNodeDeath(t *testing.T) {
+	checkIntegrationTestEnvVar(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	receivedMetrics := make(map[string][]sparkplughost.HostMetric)
+	metricHandler := func(metric sparkplughost.HostMetric) {
+		receivedMetrics[metric.Metric.GetName()] = append(receivedMetrics[metric.Metric.GetName()], metric)
+	}
+
+	hostID := fmt.Sprintf("test-host-%d", rand.Int())
+	host := sparkplughost.NewHostApplication(testBrokerURL(), hostID, sparkplughost.WithMetricHandler(metricHandler))
+
+	mqttClient := testMqttClient(t)
+	defer mqttClient.Disconnect(250)
+
+	go func() {
+		err := host.Run(ctx)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	waitForHostStatus(t, mqttClient, hostID, true)
+
+	// send an initial BIRTH message, quickly followed by a DEATH one
+	birthPayload := &protobuf.Payload{
+		Timestamp: proto.Uint64(uint64(time.Now().UnixMilli())),
+		Metrics: []*protobuf.Payload_Metric{
+			{
+				Name:     proto.String("bdSeq"),
+				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 0},
+			},
+			{
+				Name:     proto.String("foo"),
+				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
+			},
+		},
+		Seq: proto.Uint64(0),
+	}
+	protoPayload, _ := proto.Marshal(birthPayload)
+	mqttClient.Publish("spBv1.0/test-group/NBIRTH/test-node", byte(0), false, protoPayload)
+
+	deadPayload := &protobuf.Payload{
+		Metrics: []*protobuf.Payload_Metric{
+			{
+				Name:     proto.String("bdSeq"),
+				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 0},
+			},
+		},
+	}
+	protoPayload, _ = proto.Marshal(deadPayload)
+	mqttClient.Publish("spBv1.0/test-group/NDEATH/test-node", byte(0), false, protoPayload)
+
+	// Give the host some time to process the messages
+	<-ctx.Done()
+
+	fooMetric := receivedMetrics["foo"]
+
+	// we should have 2 callbacks for metric "foo": one after birth with quality: good
+	// and one after the death with quality: stale
+	if len(fooMetric) != 2 {
+		t.Errorf("received %d callbacks for metric but expected 2", len(fooMetric))
+	}
+
+	if got := fooMetric[0].Quality; got != sparkplughost.MetricQualityGood {
+		t.Errorf("got metric with Quality %s but expected GOOD", got)
+	}
+	if got := fooMetric[1].Quality; got != sparkplughost.MetricQualityStale {
+		t.Errorf("got metric with Quality %s but expected STALE", got)
+	}
+}
+
+func checkIntegrationTestEnvVar(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("MQTT_BROKER_URL") == "" {
+		t.Skip("skipping integration tests: set MQTT_BROKER_URL environment variable (e.g., tcp://localhost:1883).")
+	}
+}
+
+func testMqttClient(t *testing.T) mqtt.Client {
+	t.Helper()
+
+	mqttOpts := mqtt.NewClientOptions()
+	mqttOpts.AddBroker(testBrokerURL())
+	mqttOpts.SetClientID(fmt.Sprintf("test-client-%d", rand.Int()))
+	mqttClient := mqtt.NewClient(mqttOpts)
+
+	if token := mqttClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatal(token.Error())
+	}
+
+	return mqttClient
+}
+
+func testBrokerURL() string {
+	return os.Getenv("MQTT_BROKER_URL")
+}
+
+func waitForHostStatus(t *testing.T, mqttClient mqtt.Client, hostID string, online bool) {
+	statusChan := make(chan struct{}, 1)
+
+	token := mqttClient.Subscribe("spBv1.0/STATE/"+hostID, byte(1), func(client mqtt.Client, msg mqtt.Message) {
+		defer msg.Ack()
+
+		var payload map[string]interface{}
+
+		err := json.Unmarshal(msg.Payload(), &payload)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if payload["online"].(bool) == online {
+			statusChan <- struct{}{}
+		}
+	})
+	if token.Wait() && token.Error() != nil {
+		t.Fatal(token.Error())
+	}
+
+	select {
+	case <-statusChan:
+		return
+	case <-time.NewTicker(5 * time.Second).C:
+		t.Fatalf("timed-out waiting for death certificate")
+	}
+}

--- a/message_type.go
+++ b/message_type.go
@@ -1,0 +1,29 @@
+package sparkplughost
+
+type messageType string
+
+const (
+	messageTypeNBIRTH messageType = "NBIRTH"
+	messageTypeNDEATH messageType = "NDEATH"
+	messageTypeNDATA  messageType = "NDATA"
+	messageTypeNCMD   messageType = "NCMD"
+	messageTypeDBIRTH messageType = "DBIRTH"
+	messageTypeDDEATH messageType = "DDEATH"
+	messageTypeDDATA  messageType = "DDATA"
+	messageTypeDCMD   messageType = "DCMD"
+	messageTypeSTATE  messageType = "STATE"
+)
+
+func (m messageType) isDeviceMessage() bool {
+	return m == messageTypeDBIRTH ||
+		m == messageTypeDDEATH ||
+		m == messageTypeDDATA ||
+		m == messageTypeDCMD
+}
+
+func (m messageType) isEdgeNodeMessage() bool {
+	return m == messageTypeNBIRTH ||
+		m == messageTypeNDEATH ||
+		m == messageTypeNDATA ||
+		m == messageTypeNCMD
+}

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,86 @@
+package sparkplughost
+
+import (
+	"fmt"
+
+	"github.com/EvergenEnergy/sparkplughost/protobuf"
+)
+
+// MetricQuality will be "STALE" when a given edge node or
+// device looses connection to the MQTT broker.
+// This represents that the data was accurate at a time, but now
+// that the MQTT session has been lost can no longer be considered
+// current or up to date.
+type MetricQuality string
+
+const (
+	MetricQualityGood  MetricQuality = "GOOD"
+	MetricQualityStale MetricQuality = "STALE"
+)
+
+// HostMetric represents the view this Host Application
+// has of a particular edge node or device metric.
+type HostMetric struct {
+	EdgeNodeDescriptor EdgeNodeDescriptor
+	DeviceID           string
+	Metric             *protobuf.Payload_Metric
+	Quality            MetricQuality
+}
+
+// manages all metrics for a specific edge node
+// and its associated devices
+type edgeNodeMetrics struct {
+	edgeNodeDescriptor EdgeNodeDescriptor
+	aliasToName        map[uint64]string
+	nodeMetrics        map[string]HostMetric
+}
+
+func newEdgeNodeMetrics(edgeNodeDescriptor EdgeNodeDescriptor) *edgeNodeMetrics {
+	return &edgeNodeMetrics{
+		edgeNodeDescriptor: edgeNodeDescriptor,
+		aliasToName:        make(map[uint64]string),
+		nodeMetrics:        make(map[string]HostMetric),
+	}
+}
+
+func (m *edgeNodeMetrics) addNodeBirthMetrics(metricsProto []*protobuf.Payload_Metric) error {
+	// on edge node birth we reset all aliases/metrics.
+	aliasToName := make(map[uint64]string)
+	metrics := make(map[string]HostMetric)
+
+	for i, metric := range metricsProto {
+		metricName := metric.GetName()
+
+		if len(metricName) == 0 {
+			return fmt.Errorf("metric name is required: metrics[%d]", i)
+		}
+
+		if alias := metric.Alias; alias != nil {
+			// make sure, if supplied, that the alias is
+			// unique across this Edge Node’s entire set of metrics
+			if _, found := aliasToName[*alias]; found {
+				return fmt.Errorf("alias %d for edge node metric %s is already being used", *alias, metricName)
+			}
+
+			aliasToName[*alias] = metricName
+		}
+
+		metrics[metricName] = HostMetric{
+			EdgeNodeDescriptor: m.edgeNodeDescriptor,
+			Metric:             metric,
+			Quality:            MetricQualityGood,
+		}
+	}
+
+	m.aliasToName = aliasToName
+	m.nodeMetrics = metrics
+
+	return nil
+}
+
+func (m *edgeNodeMetrics) setNodeMetricsAsStale() {
+	for k, v := range m.nodeMetrics {
+		v.Quality = MetricQualityStale
+		m.nodeMetrics[k] = v
+	}
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,85 @@
+package sparkplughost
+
+import (
+	"testing"
+
+	"github.com/EvergenEnergy/sparkplughost/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestAddNodeBirthMetricsMissingName(t *testing.T) {
+	manager := newEdgeNodeMetrics(EdgeNodeDescriptor{})
+	metrics := []*protobuf.Payload_Metric{
+		{
+			Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+			Value:    &protobuf.Payload_Metric_LongValue{LongValue: 11},
+		},
+	}
+
+	err := manager.addNodeBirthMetrics(metrics)
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+}
+
+func TestAddNodeBirthMetricsDuplicatedAlias(t *testing.T) {
+	manager := newEdgeNodeMetrics(EdgeNodeDescriptor{})
+	metrics := []*protobuf.Payload_Metric{
+		{
+			Name:     proto.String("foo"),
+			Alias:    proto.Uint64(1),
+			Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+			Value:    &protobuf.Payload_Metric_LongValue{LongValue: 11},
+		},
+		{
+			Name:     proto.String("bar"),
+			Alias:    proto.Uint64(1),
+			Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+			Value:    &protobuf.Payload_Metric_LongValue{LongValue: 11},
+		},
+	}
+
+	err := manager.addNodeBirthMetrics(metrics)
+	if err == nil {
+		t.Error("expected error but got nil")
+	}
+}
+
+func TestAddNodeBirthMetricsValidMetrics(t *testing.T) {
+	manager := newEdgeNodeMetrics(EdgeNodeDescriptor{})
+	metrics := []*protobuf.Payload_Metric{
+		{
+			Name:     proto.String("foo"),
+			Alias:    proto.Uint64(1),
+			Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+			Value:    &protobuf.Payload_Metric_LongValue{LongValue: 11},
+		},
+		{
+			Name:     proto.String("bar"),
+			Alias:    proto.Uint64(2),
+			Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+			Value:    &protobuf.Payload_Metric_LongValue{LongValue: 11},
+		},
+	}
+
+	err := manager.addNodeBirthMetrics(metrics)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if got, want := manager.aliasToName[1], "foo"; got != want {
+		t.Errorf("got %s, wanted %s", got, want)
+	}
+
+	if got, want := manager.aliasToName[2], "bar"; got != want {
+		t.Errorf("got %s, wanted %s", got, want)
+	}
+
+	if got, want := manager.nodeMetrics["foo"].Quality, MetricQualityGood; got != want {
+		t.Errorf("got %s, wanted %s", got, want)
+	}
+
+	if got, want := manager.nodeMetrics["bar"].Quality, MetricQualityGood; got != want {
+		t.Errorf("got %s, wanted %s", got, want)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,41 @@
+package sparkplughost
+
+import (
+	"io"
+	"log/slog"
+	"time"
+)
+
+// MetricHandler is a callback type which can be set to be
+// executed upon the change of any of the known Edge Node
+// or Device metrics.
+// This includes when a metric is first received during BIRTH
+// messages as well as updates through DATA or DEATH messages.
+type MetricHandler func(HostMetric)
+
+func defaultMetricHandler(_ HostMetric) {}
+
+type config struct {
+	logger            *slog.Logger
+	metricHandler     MetricHandler
+	disconnectTimeout time.Duration
+}
+
+// Option allows clients to configure the Host Application.
+type Option func(*config)
+
+func defaultConfig() *config {
+	return &config{
+		logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		metricHandler:     defaultMetricHandler,
+		disconnectTimeout: 5 * time.Second,
+	}
+}
+
+// WithMetricHandler sets a MetricHandler to be called when metrics are
+// created or updated by this Host Application.
+func WithMetricHandler(metricHandler MetricHandler) Option {
+	return func(c *config) {
+		c.metricHandler = metricHandler
+	}
+}

--- a/topic.go
+++ b/topic.go
@@ -1,0 +1,147 @@
+package sparkplughost
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	sparkplugbNamespace = "spBv1.0"
+)
+
+type topic struct {
+	namespace   string
+	messageType messageType
+	groupID     string
+	edgeNodeID  string
+	deviceID    string
+	hostID      string
+}
+
+func (t topic) edgeNodeDescriptor() EdgeNodeDescriptor {
+	return EdgeNodeDescriptor{
+		GroupID:    t.groupID,
+		EdgeNodeID: t.edgeNodeID,
+	}
+}
+
+func parseTopic(rawTopic string) (topic, error) {
+	topicParts := strings.Split(rawTopic, "/")
+
+	if len(topicParts) < 3 {
+		return topic{}, fmt.Errorf("invalid topic: %s", rawTopic)
+	}
+
+	if topicParts[0] != sparkplugbNamespace {
+		return topic{}, fmt.Errorf("invalid namespace: %s. Only spBv1.0 is allowed", topicParts[0])
+	}
+
+	// check if this is a STATE message first since that format is different from all other
+	// message types.
+	if topicParts[1] == "STATE" {
+		if len(topicParts) != 3 || len(topicParts[2]) == 0 {
+			return topic{}, fmt.Errorf("invalid topic (%s) for STATE message. It should follow the form spBv1.0/STATE/sparkplug_host_id", rawTopic)
+		}
+
+		return topic{
+			namespace:   sparkplugbNamespace,
+			messageType: messageTypeSTATE,
+			hostID:      topicParts[2],
+		}, nil
+	}
+
+	messageType, err := parseMessageType(topicParts[2])
+	if err != nil {
+		return topic{}, err
+	}
+
+	switch {
+	case messageType.isEdgeNodeMessage():
+		return parseEdgeNodeTopic(topicParts, messageType)
+	case messageType.isDeviceMessage():
+		return parseDeviceTopic(topicParts, messageType)
+	default:
+		return topic{}, fmt.Errorf("invalid topic: %s", rawTopic)
+	}
+}
+
+func parseDeviceTopic(topicParts []string, messageType messageType) (topic, error) {
+	rawTopic := strings.Join(topicParts, "/")
+
+	if len(topicParts) != 5 {
+		return topic{}, fmt.Errorf("invalid topic (%s) for device message. It should follow the form spBv1.0/%s/edge_node_id/device_id", rawTopic, messageType)
+	}
+
+	groupID := topicParts[1]
+	if len(groupID) == 0 {
+		return topic{}, fmt.Errorf("invalid topic (%s) for edge node message. Group ID is empty", rawTopic)
+	}
+
+	edgeNodeID := topicParts[3]
+	if len(edgeNodeID) == 0 {
+		return topic{}, fmt.Errorf("invalid topic (%s) for edge node message. Edge Node ID is empty", rawTopic)
+	}
+
+	deviceID := topicParts[4]
+	if len(deviceID) == 0 {
+		return topic{}, fmt.Errorf("invalid topic (%s) for edge node message. Device ID is empty", rawTopic)
+	}
+
+	return topic{
+		namespace:   sparkplugbNamespace,
+		messageType: messageType,
+		groupID:     groupID,
+		edgeNodeID:  edgeNodeID,
+		deviceID:    deviceID,
+	}, nil
+}
+
+func parseEdgeNodeTopic(topicParts []string, messageType messageType) (topic, error) {
+	rawTopic := strings.Join(topicParts, "/")
+
+	if len(topicParts) != 4 {
+		return topic{}, fmt.Errorf("invalid topic (%s) for edge node message. It should follow the form spBv1.0/%s/edge_node_id", rawTopic, messageType)
+	}
+
+	groupID := topicParts[1]
+	if len(groupID) == 0 {
+		return topic{}, fmt.Errorf("invalid topic (%s) for edge node message. Group ID is empty", rawTopic)
+	}
+
+	edgeNodeID := topicParts[3]
+	if len(edgeNodeID) == 0 {
+		return topic{}, fmt.Errorf("invalid topic (%s) for edge node message. Edge Node ID is empty", rawTopic)
+	}
+
+	return topic{
+		namespace:   sparkplugbNamespace,
+		messageType: messageType,
+		groupID:     groupID,
+		edgeNodeID:  edgeNodeID,
+	}, nil
+}
+
+func parseMessageType(messageType string) (messageType, error) {
+	switch messageType {
+	case "STATE":
+		return messageTypeSTATE, nil
+	case "NDEATH":
+		return messageTypeNDEATH, nil
+	case "NBIRTH":
+		return messageTypeNBIRTH, nil
+	case "NDATA":
+		return messageTypeNDATA, nil
+	case "NCMD":
+		return messageTypeNCMD, nil
+	case "DBIRTH":
+		return messageTypeDBIRTH, nil
+	case "DDEATH":
+		return messageTypeDDEATH, nil
+	case "DDATA":
+		return messageTypeDDATA, nil
+	case "DCMD":
+		return messageTypeDCMD, nil
+	default:
+		return "", fmt.Errorf("invalid message type: %s", messageType)
+	}
+}

--- a/topic_test.go
+++ b/topic_test.go
@@ -1,0 +1,112 @@
+package sparkplughost
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseTopic(t *testing.T) {
+	tests := []struct {
+		topic     string
+		wantErr   bool
+		wantTopic topic
+	}{
+		{
+			// wrong namespace
+			topic:   "spAv1.0/STATE/host_id",
+			wantErr: true,
+		},
+		{
+			topic: "spBv1.0/STATE/test-host-id",
+			wantTopic: topic{
+				namespace:   "spBv1.0",
+				messageType: messageTypeSTATE,
+				hostID:      "test-host-id",
+			},
+		},
+		{
+			// missing host id
+			topic:   "spBv1.0/STATE",
+			wantErr: true,
+		},
+		{
+			// missing host id
+			topic:   "spBv1.0/STATE/foo/bar",
+			wantErr: true,
+		},
+		{
+			// empty host id
+			topic:   "spBv1.0/STATE/",
+			wantErr: true,
+		},
+		{
+			// invalid message type
+			topic:   "spBv1.0/group/NFOO/edge",
+			wantErr: true,
+		},
+		{
+			topic: "spBv1.0/test-group-id/NBIRTH/test-edge-node-id",
+			wantTopic: topic{
+				namespace:   "spBv1.0",
+				messageType: messageTypeNBIRTH,
+				groupID:     "test-group-id",
+				edgeNodeID:  "test-edge-node-id",
+			},
+		},
+		{
+			topic:   "spBv1.0/test-group-id/NBIRTH",
+			wantErr: true,
+		},
+		{
+			topic:   "spBv1.0/test-group-id/NBIRTH/edge/device",
+			wantErr: true,
+		},
+		{
+			topic:   "spBv1.0/test-group-id/NBIRTH/",
+			wantErr: true,
+		},
+		{
+			topic:   "spBv1.0//NBIRTH/test-edge-node-id",
+			wantErr: true,
+		},
+		{
+			topic: "spBv1.0/test-group-id/DBIRTH/test-edge-node-id/test-device-id",
+			wantTopic: topic{
+				namespace:   "spBv1.0",
+				messageType: messageTypeDBIRTH,
+				groupID:     "test-group-id",
+				edgeNodeID:  "test-edge-node-id",
+				deviceID:    "test-device-id",
+			},
+		},
+		{
+			topic:   "spBv1.0/test-group-id/DBIRTH/test-edge-node-id",
+			wantErr: true,
+		},
+		{
+			topic:   "spBv1.0/test-group-id/DBIRTH/test-edge-node-id/",
+			wantErr: true,
+		},
+		{
+			topic:   "spBv1.0/test-group-id/DBIRTH//test-device-id",
+			wantErr: true,
+		},
+		{
+			topic:   "spBv1.0//DBIRTH/test-edge-node-id/test-device-id",
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.topic, func(t *testing.T) {
+			got, err := parseTopic(test.topic)
+			if test.wantErr != (err != nil) {
+				t.Errorf("wantErr was %t but err was %s", test.wantErr, err)
+			}
+
+			if diff := cmp.Diff(test.wantTopic, got, cmp.AllowUnexported(topic{})); diff != "" {
+				t.Errorf("parseTopic() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Added initial API for the host application
- Added support for `STATE`, `NBIRTH` and `NDEATH` messages
- Added integration tests against a local MQTT broker