### PR TITLE
feat: add message sequence ordering logic

### DIFF
--- a/host_test.go
+++ b/host_test.go
@@ -152,7 +152,7 @@ func TestHandlesMetricsOnNodeData(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
-		})
+		}, 1)
 	}
 
 	receivedMetrics := runAndCollectAllMetrics(ctx, t, testFn)
@@ -194,7 +194,7 @@ func TestHandlesMetricsWithAliasOnNodeData(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
-		})
+		}, 1)
 	}
 
 	receivedMetrics := runAndCollectAllMetrics(ctx, t, testFn)
@@ -227,7 +227,7 @@ func TestRequestsRebirthWhenReceivingDataWithoutPreviousBirth(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
-		})
+		}, 0)
 
 		waitForRebirthRequest(t, client)
 	}
@@ -257,7 +257,7 @@ func TestRequestsRebirthWhenReceivingUnknownAlias(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
-		})
+		}, 1)
 
 		waitForRebirthRequest(t, client)
 	}
@@ -286,7 +286,7 @@ func TestRequestsRebirthWhenReceivingUnknownMetric(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
-		})
+		}, 1)
 
 		waitForRebirthRequest(t, client)
 	}
@@ -342,7 +342,7 @@ func TestHandlesMetricsOnDeviceBirth(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
 			},
-		})
+		}, 1)
 	}
 
 	receivedMetrics := runAndCollectAllMetrics(ctx, t, testFn)
@@ -384,7 +384,7 @@ func TestHandlesMetricsOnDeviceDeath(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
 			},
-		})
+		}, 1)
 		publishDeviceDeath(client)
 	}
 
@@ -423,7 +423,7 @@ func TestDeviceMetricsAreSetToStaleWhenEdgeNodeGoesOffline(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
 			},
-		})
+		}, 1)
 
 		publishNodeDeath(client)
 	}
@@ -463,14 +463,14 @@ func TestHandlesMetricsOnDeviceData(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
 			},
-		})
+		}, 1)
 		publishDeviceData(client, []*protobuf.Payload_Metric{
 			{
 				Name:     proto.String("device-metric"),
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
-		})
+		}, 2)
 	}
 
 	receivedMetrics := runAndCollectAllMetrics(ctx, t, testFn)
@@ -510,14 +510,14 @@ func TestHandlesMetricsWithAliasOnDeviceData(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
 			},
-		})
+		}, 1)
 		publishDeviceData(client, []*protobuf.Payload_Metric{
 			{
 				Alias:    proto.Uint64(11),
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
-		})
+		}, 2)
 	}
 
 	receivedMetrics := runAndCollectAllMetrics(ctx, t, testFn)
@@ -550,7 +550,7 @@ func TestRequestsRebirthWhenReceivingDeviceBirthWithoutPreviousNodeBirth(t *test
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
 			},
-		})
+		}, 0)
 
 		waitForRebirthRequest(t, client)
 	}
@@ -578,7 +578,7 @@ func TestRequestsRebirthWhenReceivingDeviceDataWithoutPreviousDeviceBirth(t *tes
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
-		})
+		}, 1)
 
 		waitForRebirthRequest(t, client)
 	}
@@ -613,7 +613,7 @@ func TestRequestsRebirthOnDuplicatedDeviceMetricAlias(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
 			},
-		})
+		}, 1)
 
 		waitForRebirthRequest(t, client)
 	}
@@ -641,14 +641,49 @@ func TestRequestsRebirthOnDeviceUnknownAlias(t *testing.T) {
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
 			},
-		})
+		}, 1)
 		publishDeviceData(client, []*protobuf.Payload_Metric{
 			{
 				Alias:    proto.Uint64(11),
 				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
 				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
 			},
+		}, 2)
+
+		waitForRebirthRequest(t, client)
+	}
+
+	runAndCollectAllMetrics(ctx, t, testFn)
+}
+
+func TestRequestsRebirthOnReorderTimeoutExpiration(t *testing.T) {
+	checkIntegrationTestEnvVar(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	testFn := func(client mqtt.Client) {
+		publishNodeBirth(client, []*protobuf.Payload_Metric{
+			{
+				Name:     proto.String("foo"),
+				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
+			},
 		})
+		publishDeviceBirth(client, []*protobuf.Payload_Metric{
+			{
+				Name:     proto.String("device-metric"),
+				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 1},
+			},
+		}, 1)
+		publishDeviceData(client, []*protobuf.Payload_Metric{
+			{
+				Name:     proto.String("device-metric"),
+				Datatype: proto.Uint32(uint32(protobuf.DataType_Int64.Number())),
+				Value:    &protobuf.Payload_Metric_LongValue{LongValue: 99},
+			},
+		}, 3)
 
 		waitForRebirthRequest(t, client)
 	}
@@ -691,11 +726,11 @@ func publishNodeDeath(mqttClient mqtt.Client) {
 	mqttClient.Publish("spBv1.0/test-group/NDEATH/test-node", byte(0), false, protoPayload)
 }
 
-func publishNodeData(mqttClient mqtt.Client, metrics []*protobuf.Payload_Metric) {
+func publishNodeData(mqttClient mqtt.Client, metrics []*protobuf.Payload_Metric, seq uint64) {
 	dataPayload := &protobuf.Payload{
 		Timestamp: proto.Uint64(uint64(time.Now().UnixMilli())),
 		Metrics:   metrics,
-		Seq:       proto.Uint64(0),
+		Seq:       proto.Uint64(seq),
 	}
 	protoPayload, _ := proto.Marshal(dataPayload)
 
@@ -703,11 +738,11 @@ func publishNodeData(mqttClient mqtt.Client, metrics []*protobuf.Payload_Metric)
 	token.Wait()
 }
 
-func publishDeviceBirth(mqttClient mqtt.Client, metrics []*protobuf.Payload_Metric) {
+func publishDeviceBirth(mqttClient mqtt.Client, metrics []*protobuf.Payload_Metric, seq uint64) {
 	birthPayload := &protobuf.Payload{
 		Timestamp: proto.Uint64(uint64(time.Now().UnixMilli())),
 		Metrics:   metrics,
-		Seq:       proto.Uint64(1),
+		Seq:       proto.Uint64(seq),
 	}
 	protoPayload, _ := proto.Marshal(birthPayload)
 
@@ -723,11 +758,11 @@ func publishDeviceDeath(mqttClient mqtt.Client) {
 	mqttClient.Publish("spBv1.0/test-group/DDEATH/test-node/test-device", byte(0), false, protoPayload)
 }
 
-func publishDeviceData(mqttClient mqtt.Client, metrics []*protobuf.Payload_Metric) {
+func publishDeviceData(mqttClient mqtt.Client, metrics []*protobuf.Payload_Metric, seq uint64) {
 	dataPayload := &protobuf.Payload{
 		Timestamp: proto.Uint64(uint64(time.Now().UnixMilli())),
 		Metrics:   metrics,
-		Seq:       proto.Uint64(0),
+		Seq:       proto.Uint64(seq),
 	}
 	protoPayload, _ := proto.Marshal(dataPayload)
 
@@ -757,6 +792,7 @@ func runAndCollectAllMetrics(ctx context.Context, t *testing.T, testFn func(mqtt
 		hostID,
 		sparkplughost.WithMetricHandler(metricHandler),
 		sparkplughost.WithLogger(logger),
+		sparkplughost.WithReorderTimeout(100*time.Millisecond),
 	)
 
 	wg.Add(1)

--- a/options.go
+++ b/options.go
@@ -19,6 +19,7 @@ type config struct {
 	logger            *slog.Logger
 	metricHandler     MetricHandler
 	disconnectTimeout time.Duration
+	reorderTimeout    time.Duration
 }
 
 // Option allows clients to configure the Host Application.
@@ -29,6 +30,7 @@ func defaultConfig() *config {
 		logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		metricHandler:     defaultMetricHandler,
 		disconnectTimeout: 5 * time.Second,
+		reorderTimeout:    5 * time.Second,
 	}
 }
 
@@ -43,5 +45,11 @@ func WithMetricHandler(metricHandler MetricHandler) Option {
 func WithLogger(logger *slog.Logger) Option {
 	return func(c *config) {
 		c.logger = logger
+	}
+}
+
+func WithReorderTimeout(timeout time.Duration) Option {
+	return func(c *config) {
+		c.reorderTimeout = timeout
 	}
 }

--- a/ordering.go
+++ b/ordering.go
@@ -1,0 +1,137 @@
+package sparkplughost
+
+import (
+	"sync"
+	"time"
+)
+
+type rebirthRequester interface {
+	requestRebirth(descriptor EdgeNodeDescriptor) error
+}
+
+// inOrderProcessor is a messageProcessor that handles the message ordering
+// requirements of the Sparkplug spec.
+// If messages arrive out of order it will buffer them internally until
+// the order is restored and then forward them to the next processor.
+// If the order is not restored within the reorderTimeout config it will
+// request a Rebirth from the node in order to reset its state.
+type inOrderProcessor struct {
+	// the ordering guarantees apply in the context of a specific Edge Node.
+	// So each one will have independent buffers, timers, etc.
+	edgeNodeProcessors map[EdgeNodeDescriptor]*edgeNodeProcessor
+	reorderTimeout     time.Duration
+	next               messageProcessor
+	rebirthRequester   rebirthRequester
+	mu                 sync.Mutex
+}
+
+func newInOrderProcessor(
+	reorderTimeout time.Duration,
+	next messageProcessor,
+	requester rebirthRequester,
+) *inOrderProcessor {
+	return &inOrderProcessor{
+		edgeNodeProcessors: make(map[EdgeNodeDescriptor]*edgeNodeProcessor),
+		reorderTimeout:     reorderTimeout,
+		next:               next,
+		rebirthRequester:   requester,
+	}
+}
+
+type edgeNodeProcessor struct {
+	// The expected sequence number of the next message.
+	expectedSeq uint64
+	// A map to store messages that are out of order. The key is the sequence number and the value is the message.
+	buffer map[uint64]sparkplugMessage
+	// A timer to track the reordering timeout.
+	reorderTimer *time.Timer
+}
+
+func (e *edgeNodeProcessor) reset() {
+	e.buffer = make(map[uint64]sparkplugMessage)
+	e.expectedSeq = 0
+	e.resetTimer()
+}
+
+func (e *edgeNodeProcessor) resetTimer() {
+	if e.reorderTimer != nil {
+		e.reorderTimer.Stop()
+
+		e.reorderTimer = nil
+	}
+}
+
+func (p *inOrderProcessor) processMessage(msg sparkplugMessage) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// if the msg doesn't have a seq number this processor can't do anything
+	// with it so just forward to the next
+	if msg.payload.Seq == nil {
+		p.next.processMessage(msg)
+		return
+	}
+
+	edgeNodeDescriptor := msg.topic.edgeNodeDescriptor()
+	msgSeqNumber := msg.payload.GetSeq()
+	nodeProcessor := p.getEdgeNodeProcessor(edgeNodeDescriptor)
+
+	// If an NBIRTH message arrives we are effectively resetting the host app
+	// view of this particular edge node, so we can clear all buffers and stop
+	// any running timers
+	if msg.topic.messageType == messageTypeNBIRTH {
+		nodeProcessor.reset()
+	}
+
+	// Adjust the expected sequence number to account for wrapping around at 255.
+	if nodeProcessor.expectedSeq > 255 {
+		nodeProcessor.expectedSeq %= 256
+	}
+
+	// If the message is in the correct order, process it immediately and reset the timer.
+	if msgSeqNumber == nodeProcessor.expectedSeq {
+		p.next.processMessage(msg)
+		nodeProcessor.expectedSeq++
+
+		nodeProcessor.resetTimer()
+	} else {
+		// The message is out of order. Store it in the buffer.
+		nodeProcessor.buffer[msgSeqNumber] = msg
+
+		// if the timer is not running yet (i.e., this is the first time we've seen
+		// an out of order msg), start it.
+		if nodeProcessor.reorderTimer == nil {
+			nodeProcessor.reorderTimer = time.AfterFunc(p.reorderTimeout, func() {
+				_ = p.rebirthRequester.requestRebirth(edgeNodeDescriptor)
+			})
+		}
+	}
+
+	// Process any buffered messages in order.
+	for seq := nodeProcessor.expectedSeq; ; seq++ {
+		msg, ok := nodeProcessor.buffer[seq]
+		if !ok {
+			// There is a gap in the sequence numbers. Stop processing buffered messages.
+			break
+		}
+
+		p.next.processMessage(msg)
+		delete(nodeProcessor.buffer, seq)
+
+		nodeProcessor.expectedSeq++
+	}
+}
+
+func (p *inOrderProcessor) getEdgeNodeProcessor(edgeNodeDescriptor EdgeNodeDescriptor) *edgeNodeProcessor {
+	nodeProcessor, ok := p.edgeNodeProcessors[edgeNodeDescriptor]
+	if !ok {
+		nodeProcessor = &edgeNodeProcessor{
+			expectedSeq: 0,
+			buffer:      make(map[uint64]sparkplugMessage),
+		}
+
+		p.edgeNodeProcessors[edgeNodeDescriptor] = nodeProcessor
+	}
+
+	return nodeProcessor
+}

--- a/ordering_test.go
+++ b/ordering_test.go
@@ -1,0 +1,464 @@
+package sparkplughost
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/EvergenEnergy/sparkplughost/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestForwardsMessagesArrivingInOrder(t *testing.T) {
+	next := newAppendProcessor()
+	processor := newInOrderProcessor(time.Second, next, newMockRebirther())
+
+	descriptor := EdgeNodeDescriptor{
+		GroupID:    "test-group",
+		EdgeNodeID: "test-node",
+	}
+
+	messages := []sparkplugMessage{
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(1)},
+		},
+	}
+
+	for _, msg := range messages {
+		processor.processMessage(msg)
+	}
+
+	expected := []sparkplugMessage{messages[0], messages[1]}
+	got := next.messagesByEdgeNode[descriptor]
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("expected messages for edge node %s/%s to be in order but weren't", descriptor.GroupID, descriptor.EdgeNodeID)
+	}
+}
+
+func TestBuffersOutOfOrderMessages(t *testing.T) {
+	next := newAppendProcessor()
+	processor := newInOrderProcessor(time.Second, next, newMockRebirther())
+
+	descriptor := EdgeNodeDescriptor{
+		GroupID:    "test-group",
+		EdgeNodeID: "test-node",
+	}
+	messages := []sparkplugMessage{
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(2)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(4)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(1)},
+		},
+	}
+
+	for _, msg := range messages {
+		processor.processMessage(msg)
+	}
+
+	// we have messages with seq number 0, 2 and 4.
+	// The first one if forwarded as soon as it arrives but 2 and 4 are buffered.
+	// When the message with seq == 1 arrives then we can forward, 1 and 2 but not 4
+	// yet because we are still missing 3.
+	expected := []sparkplugMessage{messages[0], messages[3], messages[1]}
+	got := next.messagesByEdgeNode[descriptor]
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("expected messages for edge node %s/%s to be in order but weren't", descriptor.GroupID, descriptor.EdgeNodeID)
+	}
+
+	seq3Message := sparkplugMessage{
+		topic: topic{
+			messageType: messageTypeNDATA,
+			groupID:     descriptor.GroupID,
+			edgeNodeID:  descriptor.EdgeNodeID,
+		},
+		payload: &protobuf.Payload{Seq: proto.Uint64(3)},
+	}
+	processor.processMessage(seq3Message)
+
+	// now that we processed the msg with seq == 3 we can finally forward
+	// that one and the one with seq == 4
+	expected = []sparkplugMessage{messages[0], messages[3], messages[1], seq3Message, messages[2]}
+	got = next.messagesByEdgeNode[descriptor]
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("expected messages for edge node %s/%s to be in order but weren't", descriptor.GroupID, descriptor.EdgeNodeID)
+	}
+}
+
+func TestHandlesSeqNumbersWrappingAround255(t *testing.T) {
+	next := newAppendProcessor()
+	processor := newInOrderProcessor(time.Second, next, newMockRebirther())
+
+	descriptor := EdgeNodeDescriptor{
+		GroupID:    "test-group",
+		EdgeNodeID: "test-node",
+	}
+
+	testTopic := topic{
+		messageType: messageTypeNDATA,
+		groupID:     descriptor.GroupID,
+		edgeNodeID:  descriptor.EdgeNodeID,
+	}
+
+	messages := make([]sparkplugMessage, 257)
+	for i := 0; i < 256; i++ {
+		messages[i] = sparkplugMessage{
+			topic:   testTopic,
+			payload: &protobuf.Payload{Seq: proto.Uint64(uint64(i))},
+		}
+	}
+
+	// we got messages 0 - 255 included in the slice. Add the next one which should
+	// have seq 0 again
+	messages[256] = sparkplugMessage{
+		topic:   testTopic,
+		payload: &protobuf.Payload{Seq: proto.Uint64(uint64(0))},
+	}
+
+	for _, msg := range messages {
+		processor.processMessage(msg)
+	}
+
+	got := next.messagesByEdgeNode[descriptor]
+	if !reflect.DeepEqual(messages, got) {
+		t.Errorf("expected messages for edge node %s/%s to be in order but weren't", descriptor.GroupID, descriptor.EdgeNodeID)
+	}
+}
+
+func TestReceivingAnNBIRTHMessageShouldResetAllState(t *testing.T) {
+	next := newAppendProcessor()
+	processor := newInOrderProcessor(time.Second, next, newMockRebirther())
+
+	descriptor := EdgeNodeDescriptor{
+		GroupID:    "test-group",
+		EdgeNodeID: "test-node",
+	}
+	messages := []sparkplugMessage{
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(2)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(3)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+	}
+
+	for _, msg := range messages {
+		processor.processMessage(msg)
+	}
+
+	// in this scenario we got the initial NBIRTH, which we forward
+	// we then expect the next message to have seq = 1, but we get 2 and 3.
+	// Those are buffered but after a while we get a new NBIRTH message (due to a rebirth request).
+	// This should reset the state of the inOrderProcessor since the birth message gives us the current
+	// state of all metrics.
+	// So messages with seq 2 and 3 are never forwarded.
+	expected := []sparkplugMessage{messages[0], messages[3]}
+	got := next.messagesByEdgeNode[descriptor]
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("expected messages for edge node %s/%s to be in order but weren't", descriptor.GroupID, descriptor.EdgeNodeID)
+	}
+}
+
+func TestHandlesMessagesFromDifferentEdgeNodesIndependently(t *testing.T) {
+	next := newAppendProcessor()
+	processor := newInOrderProcessor(time.Second, next, newMockRebirther())
+
+	edgeNode1 := EdgeNodeDescriptor{
+		GroupID:    "test-group",
+		EdgeNodeID: "test-node-1",
+	}
+	edgeNode2 := EdgeNodeDescriptor{
+		GroupID:    "test-group",
+		EdgeNodeID: "test-node-2",
+	}
+
+	messages := []sparkplugMessage{
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     edgeNode1.GroupID,
+				edgeNodeID:  edgeNode1.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     edgeNode1.GroupID,
+				edgeNodeID:  edgeNode1.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(1)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     edgeNode2.GroupID,
+				edgeNodeID:  edgeNode2.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     edgeNode1.GroupID,
+				edgeNodeID:  edgeNode1.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(2)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     edgeNode2.GroupID,
+				edgeNodeID:  edgeNode2.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(1)},
+		},
+	}
+
+	for _, msg := range messages {
+		processor.processMessage(msg)
+	}
+
+	expected := []sparkplugMessage{messages[0], messages[1], messages[3]}
+	got := next.messagesByEdgeNode[edgeNode1]
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("expected messages for edge node %s/%s to be in order but weren't", edgeNode1.GroupID, edgeNode1.EdgeNodeID)
+	}
+
+	expected = []sparkplugMessage{messages[2], messages[4]}
+	got = next.messagesByEdgeNode[edgeNode2]
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("expected messages for edge node %s/%s to be in order but weren't", edgeNode2.GroupID, edgeNode2.EdgeNodeID)
+	}
+}
+
+func TestRequestsANodeRebirthIfTheOrderIsNotRestoredBeforeTheTimeout(t *testing.T) {
+	rebirther := newMockRebirther()
+	reorderTimeout := 50 * time.Millisecond
+	processor := newInOrderProcessor(reorderTimeout, newAppendProcessor(), rebirther)
+
+	descriptor := EdgeNodeDescriptor{GroupID: "test-group", EdgeNodeID: "test-node"}
+	messages := []sparkplugMessage{
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(2)},
+		},
+	}
+
+	for _, msg := range messages {
+		processor.processMessage(msg)
+	}
+
+	time.Sleep(reorderTimeout + 10*time.Millisecond)
+
+	if got := rebirther.rebirthCountForEdgeNode(descriptor); got != 1 {
+		t.Errorf("expected 1 rebirth request for node %s but got %d", descriptor.String(), got)
+	}
+}
+
+func TestDoesntRequestRebirthIfOrderIsRestoredBeforeTimeout(t *testing.T) {
+	rebirther := newMockRebirther()
+	reorderTimeout := 50 * time.Millisecond
+	processor := newInOrderProcessor(reorderTimeout, newAppendProcessor(), rebirther)
+
+	descriptor := EdgeNodeDescriptor{GroupID: "test-group", EdgeNodeID: "test-node"}
+	messages := []sparkplugMessage{
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(2)},
+		},
+	}
+
+	for _, msg := range messages {
+		processor.processMessage(msg)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	processor.processMessage(sparkplugMessage{
+		topic: topic{
+			messageType: messageTypeNDATA,
+			groupID:     descriptor.GroupID,
+			edgeNodeID:  descriptor.EdgeNodeID,
+		},
+		payload: &protobuf.Payload{Seq: proto.Uint64(1)},
+	})
+
+	// sleep for the timeout duration to make sure the timer doesn't fire
+	// after processing the message.
+	time.Sleep(reorderTimeout)
+
+	if got := rebirther.rebirthCountForEdgeNode(descriptor); got != 0 {
+		t.Errorf("expected 0 rebirth request for node %s but got %d", descriptor.String(), got)
+	}
+}
+
+func TestShouldNotRequestRebirthIfNBIRTHArrives(t *testing.T) {
+	rebirther := newMockRebirther()
+	reorderTimeout := 50 * time.Millisecond
+	processor := newInOrderProcessor(reorderTimeout, newAppendProcessor(), rebirther)
+
+	descriptor := EdgeNodeDescriptor{GroupID: "test-group", EdgeNodeID: "test-node"}
+	messages := []sparkplugMessage{
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNDATA,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(2)},
+		},
+		{
+			topic: topic{
+				messageType: messageTypeNBIRTH,
+				groupID:     descriptor.GroupID,
+				edgeNodeID:  descriptor.EdgeNodeID,
+			},
+			payload: &protobuf.Payload{Seq: proto.Uint64(0)},
+		},
+	}
+
+	for _, msg := range messages {
+		processor.processMessage(msg)
+	}
+
+	time.Sleep(reorderTimeout + 10*time.Millisecond)
+
+	if got := rebirther.rebirthCountForEdgeNode(descriptor); got != 0 {
+		t.Errorf("expected 0 rebirth request for node %s but got %d", descriptor.String(), got)
+	}
+}
+
+type appendProcessor struct {
+	messagesByEdgeNode map[EdgeNodeDescriptor][]sparkplugMessage
+}
+
+func newAppendProcessor() *appendProcessor {
+	return &appendProcessor{messagesByEdgeNode: make(map[EdgeNodeDescriptor][]sparkplugMessage)}
+}
+
+func (a *appendProcessor) processMessage(msg sparkplugMessage) {
+	a.messagesByEdgeNode[msg.topic.edgeNodeDescriptor()] = append(a.messagesByEdgeNode[msg.topic.edgeNodeDescriptor()], msg)
+}
+
+type mockRebirther struct {
+	rebirthsPerNode map[EdgeNodeDescriptor]int
+	mu              sync.Mutex
+}
+
+func newMockRebirther() *mockRebirther {
+	return &mockRebirther{rebirthsPerNode: make(map[EdgeNodeDescriptor]int)}
+}
+
+func (m *mockRebirther) requestRebirth(descriptor EdgeNodeDescriptor) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.rebirthsPerNode[descriptor]++
+	return nil
+}
+
+func (m *mockRebirther) rebirthCountForEdgeNode(descriptor EdgeNodeDescriptor) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.rebirthsPerNode[descriptor]
+}


### PR DESCRIPTION
- Added ordering logic to comply with the spec

Relevant bit from https://www.eclipse.org/tahu/spec/sparkplug_spec.pdf:

```
Sparkplug Host Applications are required to validate the order of messages arriving from Edge Nodes.
This is done using the sequence number which is sent in every NBIRTH, DBIRTH, NDATA, and DDATA
message that comes from an Edge Node. Because these MQTT messages are sent on different topics, it
is possible based on MQTT Server implementations that these messages may arrive at the Sparkplug
Host Application in a different order than they were sent from the Edge Node. This can be especially
common when using clustered MQTT Servers. It is the responsibility of the Sparkplug Host Application
to ensure that all messages arrive within a Reorder Timeout. In typical environments this timeout can
be as little as a couple of seconds. In deployments with very slow networks or clustered MQTT servers
it may need to be longer. In some environments, the MQTT Server may ensure in-order delivery of
QoS0 MQTT messages even across topics. In these cases this timeout could be zero.

For example, if a Sparkplug Host Application receives messages from an Edge Node with sequence
numbers 1, 2, and 4 then at the time the message with a sequence number 4 arrives, a timer SHOULD
be started within the Host Application. This is the start of the Reordering Timeout timer. A message
with sequence number 3 MUST arrive before the Reordering Timeout elapses. If a message with
sequence number 3 does not arrive before the timeout, a Rebirth Request should be sent to the Edge
Node. This ensures that the session state is properly reestablished. If a message with a sequence
number of 3 arrives before the Reorder Timeout occurs then the timer can be shutdown and normal
operation of the Host Application can continue.
```