### PR TITLE
Using Custom GitHub Action for Coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,13 +24,8 @@ jobs:
           MQTT_BROKER_URL: "tcp://localhost:1883"
         run: go test -race -v -covermode atomic -coverprofile=covprofile ./...
 
-      - name: Install goveralls
-        run: go install github.com/mattn/goveralls@latest
-
-      - name: Send coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: goveralls -coverprofile=covprofile -service=github
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As indicated above, using the dedicated GitHub action instead of installing things locally.