### PR TITLE
ci: run workflow on PRs and pushes to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   test:
     name: Build and test


### PR DESCRIPTION
We are currently running the `ci` workflow twice for each commit:
- once for the `push` event
- once for the `pull_request` event

![Screenshot 2023-11-16 at 16 25 34](https://github.com/EvergenEnergy/sparkplug-host/assets/1747562/ebd0ea80-7e8f-46a2-82dd-e285dedd2a1d)

This PR adds a filter to the `push` event to only run it when the push happens against `main` (and still on PRs)