### PR TITLE
feat: add cache handler

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,126 @@
+package sparkplughost
+
+import (
+	"fmt"
+	"sync"
+)
+
+// CachingHandler is a MetricHandler that stores the latest known state
+// of every metric in memory.
+// It allows clients to get a snapshot view of all the current Edge Nodes
+// and Devices on-demand.
+// All operations in this handler are safe for concurrent use.
+type CachingHandler struct {
+	mu      sync.RWMutex
+	metrics map[string]HostMetric
+
+	// reverse indexes from group/node/device id
+	// to all metric keys for that component in the
+	// metrics map above
+	byGroup    map[string][]string
+	byEdgeNode map[EdgeNodeDescriptor][]string
+	byDevice   map[string][]string
+}
+
+// NewCachingHandler returns a new handler ready to be used.
+func NewCachingHandler() *CachingHandler {
+	return &CachingHandler{
+		metrics:    make(map[string]HostMetric),
+		byGroup:    make(map[string][]string),
+		byEdgeNode: make(map[EdgeNodeDescriptor][]string),
+		byDevice:   make(map[string][]string),
+	}
+}
+
+// HandleMetric is a MetricHandler function that can be passed to
+// WithMetricHandler when creating the HostApplication.
+func (c *CachingHandler) HandleMetric(metric HostMetric) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	metricKey := metricKey(metric)
+	deviceKey := deviceKey(metric.EdgeNodeDescriptor, metric.DeviceID)
+
+	c.metrics[metricKey] = metric
+
+	c.byGroup[metric.EdgeNodeDescriptor.GroupID] = append(c.byGroup[metric.EdgeNodeDescriptor.GroupID], metricKey)
+	c.byEdgeNode[metric.EdgeNodeDescriptor] = append(c.byEdgeNode[metric.EdgeNodeDescriptor], metricKey)
+	c.byDevice[deviceKey] = append(c.byDevice[deviceKey], metricKey)
+}
+
+// AllMetrics returns all currently known metrics in the MQTT infrastructure.
+func (c *CachingHandler) AllMetrics() []HostMetric {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	res := make([]HostMetric, 0, len(c.metrics))
+	for _, metric := range c.metrics {
+		res = append(res, metric)
+	}
+
+	return res
+}
+
+// DeviceMetrics returns all known metrics for a specific Device.
+func (c *CachingHandler) DeviceMetrics(descriptor EdgeNodeDescriptor, deviceID string) []HostMetric {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	deviceMetrics, found := c.byDevice[deviceKey(descriptor, deviceID)]
+	if !found {
+		return nil
+	}
+
+	return c.collectMetrics(deviceMetrics)
+}
+
+// EdgeNodeMetrics returns all known metrics for a specific Edge Node.
+// This includes the metrics for Devices associated with that Edge Node.
+func (c *CachingHandler) EdgeNodeMetrics(descriptor EdgeNodeDescriptor) []HostMetric {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	nodeMetrics, found := c.byEdgeNode[descriptor]
+	if !found {
+		return nil
+	}
+
+	return c.collectMetrics(nodeMetrics)
+}
+
+// GroupMetrics returns all known metrics for a specific Group.
+// This includes all Edge Nodes and Devices in that group.
+func (c *CachingHandler) GroupMetrics(groupID string) []HostMetric {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	groupMetrics, found := c.byGroup[groupID]
+	if !found {
+		return nil
+	}
+
+	return c.collectMetrics(groupMetrics)
+}
+
+func metricKey(metric HostMetric) string {
+	return fmt.Sprintf("%s/%s/%s", metric.EdgeNodeDescriptor, metric.DeviceID, metric.Metric.GetName())
+}
+
+func deviceKey(descriptor EdgeNodeDescriptor, deviceID string) string {
+	return fmt.Sprintf("%s/%s", descriptor, deviceID)
+}
+
+func (c *CachingHandler) collectMetrics(metricKeys []string) []HostMetric {
+	res := make([]HostMetric, len(metricKeys))
+
+	for i, mk := range metricKeys {
+		metric, ok := c.metrics[mk]
+		if !ok {
+			continue
+		}
+
+		res[i] = metric
+	}
+
+	return res
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,70 @@
+package sparkplughost_test
+
+import (
+	"testing"
+
+	"github.com/EvergenEnergy/sparkplughost"
+	"github.com/EvergenEnergy/sparkplughost/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+var metrics = []sparkplughost.HostMetric{
+	{
+		EdgeNodeDescriptor: sparkplughost.EdgeNodeDescriptor{GroupID: "group-1", EdgeNodeID: "node-1"},
+		Metric:             &protobuf.Payload_Metric{Name: proto.String("node-metric-1")},
+	},
+	{
+		EdgeNodeDescriptor: sparkplughost.EdgeNodeDescriptor{GroupID: "group-1", EdgeNodeID: "node-1"},
+		DeviceID:           "device-1",
+		Metric:             &protobuf.Payload_Metric{Name: proto.String("device-metric-1")},
+	},
+	{
+		EdgeNodeDescriptor: sparkplughost.EdgeNodeDescriptor{GroupID: "group-2", EdgeNodeID: "node-2"},
+		DeviceID:           "device-2",
+		Metric:             &protobuf.Payload_Metric{Name: proto.String("device-metric-2")},
+	},
+}
+
+func TestCachingHandler(t *testing.T) {
+	handler := sparkplughost.NewCachingHandler()
+
+	for _, metric := range metrics {
+		handler.HandleMetric(metric)
+	}
+
+	groupMetrics := handler.GroupMetrics("group-2")
+	if len(groupMetrics) != 1 {
+		t.Errorf("expected 1 metric for group-2 but got %d", len(groupMetrics))
+	}
+
+	groupMetrics = handler.GroupMetrics("group-1")
+	if len(groupMetrics) != 2 {
+		t.Errorf("expected 2 metrics for group-1 but got %d", len(groupMetrics))
+	}
+
+	groupMetrics = handler.GroupMetrics("group-3")
+	if len(groupMetrics) != 0 {
+		t.Errorf("expected 0 metrics for group-3 but got %d", len(groupMetrics))
+	}
+
+	edgeNodeMetrics := handler.EdgeNodeMetrics(sparkplughost.EdgeNodeDescriptor{
+		GroupID:    "group-1",
+		EdgeNodeID: "node-1",
+	})
+	if len(edgeNodeMetrics) != 2 {
+		t.Errorf("expected 2 metric for node-1 but got %d", len(edgeNodeMetrics))
+	}
+
+	deviceMetrics := handler.DeviceMetrics(sparkplughost.EdgeNodeDescriptor{
+		GroupID:    "group-1",
+		EdgeNodeID: "node-1",
+	}, "device-1")
+	if len(deviceMetrics) != 1 {
+		t.Errorf("expected 1 metric for device-1 but got %d", len(deviceMetrics))
+	}
+
+	allMetrics := handler.AllMetrics()
+	if len(allMetrics) != 3 {
+		t.Errorf("expected 3 metric but got %d", len(allMetrics))
+	}
+}


### PR DESCRIPTION
- Add a metric handler that caches the latest value for each one
- This should allow us to periodically query the state of all metrics for a given group