### PR TITLE
fix: Fix memory leak in metric Cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,4 +47,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.56.2

--- a/cache_test.go
+++ b/cache_test.go
@@ -68,3 +68,16 @@ func TestCachingHandler(t *testing.T) {
 		t.Errorf("expected 3 metric but got %d", len(allMetrics))
 	}
 }
+
+func TestProcessingTheSameMetricMultipleTimes(t *testing.T) {
+	handler := sparkplughost.NewCachingHandler()
+
+	for i := 0; i < 100; i++ {
+		handler.HandleMetric(metrics[0])
+	}
+
+	allMetrics := handler.EdgeNodeMetrics(metrics[0].EdgeNodeDescriptor)
+	if len(allMetrics) != 1 {
+		t.Errorf("expected 1 metric but got %d", len(allMetrics))
+	}
+}

--- a/examples/client-certs/handlers.go
+++ b/examples/client-certs/handlers.go
@@ -86,7 +86,6 @@ func handleMetricWriteRequest(host *sparkplughost.HostApplication, logger *slog.
 				GroupID:    groupID,
 				EdgeNodeID: edgeNodeID,
 			}, protoMetrics)
-
 		} else {
 			err = host.SendDeviceCommand(sparkplughost.EdgeNodeDescriptor{
 				GroupID:    groupID,

--- a/host.go
+++ b/host.go
@@ -123,7 +123,7 @@ func (h *HostApplication) initClients() {
 		mqttOpts.SetOrderMatters(true)
 		mqttOpts.SetOnConnectHandler(h.onConnect(brokerURL))
 		mqttOpts.SetReconnectingHandler(h.onReconnect(brokerURL))
-		mqttOpts.SetDefaultPublishHandler(func(_ mqtt.Client, message mqtt.Message) {})
+		mqttOpts.SetDefaultPublishHandler(func(_ mqtt.Client, _ mqtt.Message) {})
 
 		if len(brokerConfig.Username) > 0 {
 			mqttOpts.SetUsername(brokerConfig.Username)
@@ -210,13 +210,13 @@ func (h *HostApplication) onConnect(brokerURL string) mqtt.OnConnectHandler {
 }
 
 func (h *HostApplication) onReconnect(brokerURL string) mqtt.ReconnectHandler {
-	return func(client mqtt.Client, options *mqtt.ClientOptions) {
+	return func(_ mqtt.Client, options *mqtt.ClientOptions) {
 		h.setLastWill(brokerURL, options)
 	}
 }
 
 func (h *HostApplication) stateHandler(brokerURL string) mqtt.MessageHandler {
-	return func(client mqtt.Client, message mqtt.Message) {
+	return func(_ mqtt.Client, message mqtt.Message) {
 		// the STATE topic uses QOS 1, so we need to make sure we ACK the message
 		defer message.Ack()
 

--- a/ordering.go
+++ b/ordering.go
@@ -91,6 +91,7 @@ func (p *inOrderProcessor) processMessage(msg sparkplugMessage) {
 	// If the message is in the correct order, process it immediately and reset the timer.
 	if msgSeqNumber == nodeProcessor.expectedSeq {
 		p.next.processMessage(msg)
+
 		nodeProcessor.expectedSeq++
 
 		nodeProcessor.resetTimer()


### PR DESCRIPTION
The current cache keeps an index of metric keys which are then used to quickly retrieve all metrics for a specific group/edge node/device.

The problem is that we currently store those metric keys in a `[]string` without checking if we already have a value for that metric. So as we process the same set of metrics over and over that list continues growing indefinitely.

This PR fixes that by storing those keys in a `map[string]struct{}` which acts as a unique set of keys.