### PR TITLE
Update osv-scanner workflow

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,19 +1,21 @@
 name: OSV-Scanner PR Scan
 
+# From https://google.github.io/osv-scanner/github-action/
+
 on:
   pull_request:
     branches: [ main ]
   merge_group:
     branches: [ main ]
 
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
 jobs:
-  vuln-scan:
-    name: Run osv-scanner
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21.x'
-      - uses: google/osv-scanner/actions/scanner@main
+  scan-pr:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.2.1"


### PR DESCRIPTION
Replace contents of osv-scanner workflow, currently failing with a docker build error, with the example provided by https://google.github.io/osv-scanner/github-action/