### PR TITLE
use updated scanner action

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,6 +1,7 @@
 name: OSV-Scanner PR Scan
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
   merge_group:
@@ -15,5 +16,5 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.x'
-      - uses: google/osv-scanner/actions/scanner@main
+          go-version: '1.24.x'
+      - uses: google/osv-scanner/actions/scanner@v2.2.2


### PR DESCRIPTION
Try just updating the scanner action version - referencing `main` caused a docker build error, but the current version is 2.2.2. Switching to the reusable PR isn't working, probably due to preconfigured branch protection rules requiring a specific name.